### PR TITLE
Fix: timeline in programs page breaking

### DIFF
--- a/src/Components/Programs/Timeline.js
+++ b/src/Components/Programs/Timeline.js
@@ -58,14 +58,14 @@ function Timeline() {
                                     color:item.color,
                                     borderColor:item.color,
                                     flex:1,
-                                    left:item.date[0][2]*10,
+                                    left:item.date[2][1]*10,
                                     borderRadius: 50,
                                     zIndex:1,
                                     }}
                                 >
                                     {item.event}
                                 </Event>
-                                <Stroke style={{width:(item.date[0][1]+5)*20}}></Stroke>
+                                <Stroke style={{width:(item.date[2][1]+5)*50}}></Stroke>
                             </View>
                         ))
                     }


### PR DESCRIPTION
### Description

Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change.

To resolve this issue currently i had changed the positioning value as previously the `date[0][1]` for both the events are different which results in incorrect positioning of timeline page now it has been resolved by consumig value `date[2][1]` as it is nearly same for both the events.

Fixes #246 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
deployment link: https://hardcore-booth-457055.netlify.app/


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have attached link of deployed site.


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
