### PR TITLE
Fix #263 : Replaced Text links with href

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dayjs": "^1.9.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-native-hyperlink": "0.0.19",
     "react-native-reflect": "^0.1.6",
     "react-native-web": "^0.12.2",
     "react-scripts": "^3.4.1"

--- a/src/Components/AboutUs/index.js
+++ b/src/Components/AboutUs/index.js
@@ -4,6 +4,7 @@ import content from '../../content/about_us.json';
 import ImageContent from './../ImageContent';
 import { MainContainer, Box, Content, Description } from './styles';
 import OSCommunity from './Oscommunity';
+import Hyperlink from 'react-native-hyperlink';
 
 function AboutUs() {
   const renderContent = () => {
@@ -14,7 +15,11 @@ function AboutUs() {
             <Content key={index}>
               <SectionSubheader title={section.title} />
               {section.content.map((content, indx) => {
-                return <Description key={indx}>{content.par}</Description>;
+                return <Hyperlink linkStyle={ { color: '#2980b9'} } onPress={(url)=> window.open(url,'_blank')}>
+                  <Description key={indx}>
+                    {content.par}
+                  </Description>
+                </Hyperlink>;
               })}
             </Content>
           );

--- a/src/Components/Contribute/index.js
+++ b/src/Components/Contribute/index.js
@@ -3,6 +3,7 @@ import SectionHeader from '../SectionHeader';
 import content from '../../content/contributeIntro.json';
 import ImageContent from './../ImageContent';
 import { MainContainer, Box, Content, Description } from './style';
+import Hyperlink from 'react-native-hyperlink';
 
 function Contribute() {
     const renderContent = () => {
@@ -13,7 +14,11 @@ function Contribute() {
                         <Content key={index}>
                             <SectionHeader title={section.title} />
                             {section.content.map((content,index) => {
-                                return <Description key={index}>{content.par}</Description>;
+                                return <Hyperlink  linkStyle={ { color: '#2980b9'} } onPress={(url)=> window.open(url,'_blank')}>
+                                <Description key={index}>
+                                  {content.par}
+                                </Description>
+                              </Hyperlink>;
                             })}
                         </Content>
                     );

--- a/src/Components/Footer/Contact.js
+++ b/src/Components/Footer/Contact.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import styles from './styles';
 import contentJson from '../../content/contact_us.json';
+import Hyperlink from 'react-native-hyperlink';
 
 function Contact() {
   const content = contentJson.sections.find(
@@ -12,9 +13,11 @@ function Contact() {
     <View style={[styles.col, styles.right]}>
       <Text style={[styles.text, styles.heading]}>Contact Us</Text>
       {content.map((content, i) => (
-        <Text style={[styles.text, styles.description]} key={i}>
+        <Hyperlink linkStyle={ { color: '#2980b9'} } onPress={(url)=> window.open(url,'_blank')}>
+          <Text style={[styles.text, styles.description]} key={i}>
           {content.par}
-        </Text>
+          </Text>
+        </Hyperlink>
       ))}
     </View>
   );


### PR DESCRIPTION
### Description

Replaced the text links in `AboutUs`, `Contribute` pages and in Footer with `href`, and hence they are clickable and open the links in a new tab.

Fixes #263 

### Type of Change:

- Code

### How Has This Been Tested?

- Tested on localhost
- Below are the gif before and after the Fix

**Before :**
 
![before-href](https://user-images.githubusercontent.com/56157418/115508042-8120b600-a29a-11eb-99c1-fe2d89d406f7.gif)



**After :**

![after-href](https://user-images.githubusercontent.com/56157418/115508302-c8a74200-a29a-11eb-8fd4-5b9d0c27c942.gif)




### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings

**Dependencies Used :**
- [react-native-hyperlink](https://www.npmjs.com/package/react-native-hyperlink)
