### PR TITLE
chore: update action to ensure we get the reference before running "prettier"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.0
         with:
-          prettier_options: --write src/**/*.{js,json,md}
+          prettier_options: "src/**/*.{ts,jsx,js,css,html,json,md}" --write
           only_changed: True
   build:
     # The type of runner that the job will run on


### PR DESCRIPTION
### Description

In order to fix the current problem we have with the action that is executed for "prettier", this PR forces that within the checkout action we always have the last reference (from current branch or pull-request).

### Type of Change:

- Chore (Process update)

### Issues

Fixes: #310

----
**References**

- https://github.com/anitab-org/anitab-org.github.io/pull/296#issuecomment-945129368 