### PR TITLE
fix: content overlap in events page

### DIFF
--- a/src/Components/Events/index.js
+++ b/src/Components/Events/index.js
@@ -5,7 +5,7 @@ import { getevents_highlights } from './../../content/events_and_highlights';
 import SectionSubheader from './../SectionSubheader';
 import GoogleCalendar from './GoogleCalendar';
 import content from '../../content/events_calendar.json';
-import { Box, MainContainer, Content, Description, List } from './style';
+import { MainContainer, Content, Description, List } from './style';
 import OurEvents from '../OurEvents/index';
 
 const events_highlight = getevents_highlights();

--- a/src/Components/Events/style.js
+++ b/src/Components/Events/style.js
@@ -12,12 +12,6 @@ export const MainContainer = styled(View, {
   marginBottom: 32,
 });
 
-export const Box = styled(View, {
-  flex: 1,
-  flexDirection: 'column',
-  marginTop: -32,
-});
-
 export const Content = styled(View, {
   flexDirection: 'column',
   paddingLeft: 16,


### PR DESCRIPTION
### Description

Fix content overlap in events page.

Fixes #303 

### Type of Change:

**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

https://arisaokasaka.github.io/anitab-org.github.io/

<img width="865" alt="スクリーンショット 2021-10-18 0 57 29" src="https://user-images.githubusercontent.com/68284764/137635159-f387e71f-6908-4d74-853c-ac5ca6d42627.png">

### Checklist:

**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have attached link of deployed site.
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
