### PR TITLE
feat: add programs and projects information to programs page

### DIFF
--- a/src/Components/Programs/ProgramsTableSection/ProgramsTable.js
+++ b/src/Components/Programs/ProgramsTableSection/ProgramsTable.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import ProgramsTableRow from './ProgramsTableRow';
+import {
+  TableContainer,
+  TableTitle,
+} from './styles';
+
+
+function ProgramsTable({ table }) {
+  return (
+    <TableContainer>
+      <TableTitle>{table.title}</TableTitle>
+      <ProgramsTableRow row={table.tableHeaders} isHeader={true} />
+      {
+        table.tableRows.map((row, index) => {
+          return (<ProgramsTableRow key={index} row={row} isHeader={false} />);
+        })
+      }
+    </TableContainer>
+  )
+}
+
+export default ProgramsTable;

--- a/src/Components/Programs/ProgramsTableSection/ProgramsTableRow.js
+++ b/src/Components/Programs/ProgramsTableSection/ProgramsTableRow.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+  TableHeaderRow,
+  TableDataRow,
+  TableHeader,
+  TableHeaderText,
+  TableData,
+  TableDataText,
+} from './styles';
+
+function ProgramsTableRow({ row, isHeader }) {
+
+  if (isHeader) {
+    return (
+      <TableHeaderRow>
+        {
+          row.map((data, index) => {
+            return (
+              <TableHeader key={index} style={(index < row.length - 1) && {marginRight: 5}}>
+                <TableHeaderText>{data}</TableHeaderText>
+              </TableHeader>
+            )
+          })
+        }
+      </TableHeaderRow>
+    );
+  }
+
+  return (
+    <TableDataRow>
+      {
+        row.map((data, index) => {
+          return (
+            <TableData key={index} style={(index < row.length -1) && { marginRight: 5 }}>
+              <TableDataText>{data}</TableDataText>
+            </TableData>
+          )
+        })
+      }
+    </TableDataRow>
+  );
+}
+
+export default ProgramsTableRow;

--- a/src/Components/Programs/ProgramsTableSection/ProgramsTablesSection.js
+++ b/src/Components/Programs/ProgramsTableSection/ProgramsTablesSection.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import programs from '../../../content/programs.json';
+import ProgramsTable from './ProgramsTable';
+import {
+  SectionContainer,
+  SectionHeader,
+  SectionTableContainer
+} from './styles';
+
+
+function ProgramsTableSection() {
+  const content = programs;
+
+  return (
+    <>
+      {
+        content.map((section, index) => {
+          return (
+            <SectionContainer key={index}>
+              <SectionHeader>
+                {section.sectionHeader}
+              </SectionHeader>
+              <SectionTableContainer>
+                {
+                  section.tables.map((table, index) => {
+                    return (<ProgramsTable key={index} table={table} />);
+                  })
+                }
+              </SectionTableContainer>
+            </SectionContainer>
+          );
+        })
+      }
+    </>
+  );
+}
+
+export default ProgramsTableSection;

--- a/src/Components/Programs/ProgramsTableSection/styles.js
+++ b/src/Components/Programs/ProgramsTableSection/styles.js
@@ -29,7 +29,7 @@ export const TableContainer = styled(View, {
 export const TableTitle = styled(Text, {
   fontSize: 16,
   fontWeight: 500,
-  backgroundColor: '#231B4E',
+  backgroundColor: '#005C88',
   marginBottom: 1,
   paddingVertical: 8,
   color: 'white',
@@ -56,14 +56,14 @@ export const TableHeader = styled(View, {
 export const TableHeaderText = styled(Text, {
   color: 'white',
   fontWeight: 500,
-  backgroundColor: '#231B4E',
+  backgroundColor: '#005C88',
   paddingVertical: 8,
 });
 
 export const TableData = styled(View, {
   flex: 1,
   alignSelf: 'stretch',
-  backgroundColor: '#464e1b',
+  backgroundColor: '#54BCEB',
   justifyContent: 'center',
   padding: 8,
 });

--- a/src/Components/Programs/ProgramsTableSection/styles.js
+++ b/src/Components/Programs/ProgramsTableSection/styles.js
@@ -8,11 +8,10 @@ export const SectionContainer = styled(View, {
 });
 
 export const SectionHeader = styled(Text, {
-  fontSize: 20,
-  fontWeight: 600,
-  backgroundColor: 'purple',
+  fontSize: 32,
+  fontWeight: 400,
   textAlign: 'center',
-  color: 'white',
+  color: '#103B81',
 });
 
 export const SectionTableContainer = styled(View, {
@@ -24,14 +23,15 @@ export const SectionTableContainer = styled(View, {
 export const TableContainer = styled(View, {
   width: '80vw',
   textAlign: 'center',
+  marginTop: 32,
 });
 
 export const TableTitle = styled(Text, {
   fontSize: 16,
   fontWeight: 500,
-  backgroundColor: 'mediumpurple',
-  marginBottom: 2,
-  marginTop: 2,
+  backgroundColor: '#231B4E',
+  marginBottom: 1,
+  paddingVertical: 8,
   color: 'white',
 });
 
@@ -45,7 +45,7 @@ export const TableDataRow = styled(View, {
   flex: 1,
   alignSelf: 'stretch',
   flexDirection: 'row',
-  marginTop: 2,
+  marginTop: 1,
 });
 
 export const TableHeader = styled(View, {
@@ -54,18 +54,21 @@ export const TableHeader = styled(View, {
 });
 
 export const TableHeaderText = styled(Text, {
+  color: 'white',
   fontWeight: 500,
-  backgroundColor: 'lightblue',
+  backgroundColor: '#231B4E',
+  paddingVertical: 8,
 });
 
 export const TableData = styled(View, {
   flex: 1,
   alignSelf: 'stretch',
-  backgroundColor: 'orange',
+  backgroundColor: '#464e1b',
   justifyContent: 'center',
-  padding: 10,
+  padding: 8,
 });
 
 export const TableDataText = styled(Text, {
   color: 'white',
+  opacity: 1,
 })

--- a/src/Components/Programs/ProgramsTableSection/styles.js
+++ b/src/Components/Programs/ProgramsTableSection/styles.js
@@ -70,5 +70,4 @@ export const TableData = styled(View, {
 
 export const TableDataText = styled(Text, {
   color: 'white',
-  opacity: 1,
 })

--- a/src/Components/Programs/ProgramsTableSection/styles.js
+++ b/src/Components/Programs/ProgramsTableSection/styles.js
@@ -1,0 +1,71 @@
+import { View, Text } from 'react-native';
+import { styled } from 'react-native-reflect';
+
+
+export const SectionContainer = styled(View, {
+  marginTop: 40,
+  width: '80vw',
+});
+
+export const SectionHeader = styled(Text, {
+  fontSize: 20,
+  fontWeight: 600,
+  backgroundColor: 'purple',
+  textAlign: 'center',
+  color: 'white',
+});
+
+export const SectionTableContainer = styled(View, {
+  flex: 1,
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+export const TableContainer = styled(View, {
+  width: '80vw',
+  textAlign: 'center',
+});
+
+export const TableTitle = styled(Text, {
+  fontSize: 16,
+  fontWeight: 500,
+  backgroundColor: 'mediumpurple',
+  marginBottom: 2,
+  marginTop: 2,
+  color: 'white',
+});
+
+export const TableHeaderRow = styled(View, {
+  flex: 1,
+  alignSelf: 'stretch',
+  flexDirection: 'row',
+});
+
+export const TableDataRow = styled(View, {
+  flex: 1,
+  alignSelf: 'stretch',
+  flexDirection: 'row',
+  marginTop: 2,
+});
+
+export const TableHeader = styled(View, {
+  flex: 1,
+  alignSelf: 'stretch',
+});
+
+export const TableHeaderText = styled(Text, {
+  fontWeight: 500,
+  backgroundColor: 'lightblue',
+});
+
+export const TableData = styled(View, {
+  flex: 1,
+  alignSelf: 'stretch',
+  backgroundColor: 'orange',
+  justifyContent: 'center',
+  padding: 10,
+});
+
+export const TableDataText = styled(Text, {
+  color: 'white',
+})

--- a/src/Components/Programs/index.js
+++ b/src/Components/Programs/index.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import Timeline from './Timeline';
+import ProgramsTableSection from './ProgramsTableSection/ProgramsTablesSection';
+
 function Programs() {
   return (
     <>
       <Timeline></Timeline>
+      <ProgramsTableSection></ProgramsTableSection>
     </>
   );
 }
+
 export default Programs;

--- a/src/content/programs.json
+++ b/src/content/programs.json
@@ -231,5 +231,175 @@
         ]
       }
     ]
+  },
+  {
+    "sectionHeader": "Google Summer of Code 2016",
+    "tables": [
+      {
+        "title": "Peace Corps Projects",
+        "tableHeaders": [
+          "Project",
+          "Student",
+          "Project Manager & Mentor",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "Malaria (Android)",
+            "Yatna (India)",
+            "Nicki (USA)",
+            "Ankita (India)\nLeroi"
+          ],
+          [
+            "Malaria (iOS)",
+            "Teodor (Romania)",
+            "Nicki (USA)",
+            "Bruno (Portugal)\nJayaruwan"
+          ],
+          [
+            "Malaria (Web)",
+            "Ananta",
+            "Nicki (USA)",
+            "Khushali\nRitesh\nRheeya"
+          ],
+          [
+            "PCSA (Android)",
+            "Rohan",
+            "Nicki (USA)",
+            "Dinu (Sri Lanka)\nBuddhiprabha (Sri Lanka)\nIlo (Nigeria)"
+          ],
+          [
+            "PCSA (iOS)",
+            "Chamika",
+            "Nicki (USA)",
+            "Shruti (India)"
+          ],
+          [
+            "PCSA (Web)",
+            "Akanksha (Sri Lanka)",
+            "Maybellin",
+            "Prajakta\nThemiya"
+          ],
+          [
+            "Mobile App Control Center",
+            "Medha",
+            "",
+            "Neetu (USA)\nIrish (Canada)\nAngel\nLorena"
+          ],
+          [
+            "Peace Corps Hub",
+            "Izabela",
+            "Rose (USA)",
+            "Jessica"
+          ],
+          [
+            "Ushahidi Crowdmap",
+            "Divya (India)",
+            "Julia (USA)",
+            ""
+          ],
+          [
+            "Photo Language Translation",
+            "Rupinderjit",
+            "Rose (USA)",
+            "Saumya (India)\nValerie (USA)\nSaurabh"
+          ]
+        ]
+      },
+      {
+        "title": "Systers Projects",
+        "tableHeaders": [
+          "Project",
+          "Student",
+          "Project Manager & Mentor",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "Portal",
+            "Payal",
+            "Rose (USA)",
+            "Jiaqi\nNida\nCarol (USA)\nAna (Moldova)"
+          ],
+          [
+            "VMS",
+            "Pranjali",
+            "Rose (USA)",
+            "Tapasweni (India)"
+          ],
+          [
+            "Meetup",
+            "Amrutha",
+            "Rose (USA)",
+            "Nida\nJiaqui\nShaifhali (India)\nAna (Moldova)"
+          ],
+          [
+            "Mailman 3",
+            "Aditi",
+            "Ana (Spain)",
+            "Stephen (Japan)"
+          ],
+          [
+            "PowerUp (Android)",
+            "Aanchal",
+            "",
+            "Finda\nChhavi\nHarshita"
+          ],
+          [
+            "PowerUp (iOS)",
+            "Sanya (India)",
+            "",
+            "Finda\nJennifer (Austria)"
+          ]
+        ]
+      },
+      {
+        "title": "Systers Automated Testing",
+        "tableHeaders": [
+          "Project",
+          "Student",
+          "Project Manager & Mentor",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "Malaria (Web)",
+            "Shraddha",
+            "",
+            "Shwetambara"
+          ],
+          [
+            "PCSA Web",
+            "Anjali (India)",
+            "",
+            "Mariam"
+          ],
+          [
+            "MACC",
+            "Tahirih",
+            "Nicki (USA)",
+            "Suryadip (USA)\nKesha (India)"
+          ],
+          [
+            "PCHUB",
+            "Daisy (Cameroon)",
+            "Rose (USA)",
+            "Nidhi"
+          ],
+          [
+            "Photo Language Translation",
+            "Madi (USA)",
+            "",
+            "Mariam"
+          ],
+          [
+            "Portal",
+            "Vatsala",
+            "Rose (USA)",
+            "Nidhi"
+          ]
+        ]
+      }
+    ]
   }
 ]

--- a/src/content/programs.json
+++ b/src/content/programs.json
@@ -35,6 +35,76 @@
     ]
   },
   {
+    "sectionHeader": "Google Summer of Code 2018",
+    "tables": [
+      {
+        "title": "Systers Community 2018 Projects",
+        "tableHeaders": [
+          "Project",
+          "Student",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "GH Pages for Systers",
+            "Anumeha Agrawal",
+            "Tharangi\nMay\nRupinderjit Kaur\nKanika Modi"
+          ],
+          [
+            "Github Pages",
+            "Baani Leen Kaur Jolly",
+            "Janiceilene\nMay\nBethany Rentz\nAncy Philip"
+          ],
+          [
+            "Infrastructure and Automation of Web projects in Python.",
+            "Monal Shadi",
+            "Ayush Garg\nPrachi Manchanda\nNaman Maheshwari\nMeha Kaushik"
+          ],
+          [
+            "Infrastructure/Automation-Android",
+            "Anamika Tripathi",
+            "May\nNikita Jibhkate\nManju"
+          ],
+          [
+            "Mentorship System",
+            "Isabel Costa",
+            "Roopal Jain\nMay\nDilushi Piumwardane\nMurad"
+          ],
+          [
+            "Out-of-Character Contextual Information for PowerUp!",
+            "Cady",
+            "May\nginny"
+          ],
+          [
+            "PC Prep Kit",
+            "Mayank Lunayach",
+            "Buddhiprabha Erabadda\nS J Rajath Krishna\nShreyans Shrimal\nPaavini Nanda"
+          ],
+          [
+            "PowerUp-Android",
+            "Rimjhim Bhadani",
+            "May\nDebanjana\nThisum\nJeanna Clark"
+          ],
+          [
+            "Proposal for Systers Portal",
+            "Abhijit Kumar",
+            "Prachi Manchanda\nYatna Verma\nPoojitha Nandigam"
+          ],
+          [
+            "Sysbot",
+            "Sombuddha Chakravarty",
+            "Sarah Masud\nRamit Sawhney\nPrachi Manchanda"
+          ],
+          [
+            "Volunteer Management System(VMS)",
+            "Anjali Dhanuka",
+            "May\nAbhishek Arya\nnida\nKamakshi Suri"
+          ]
+        ]
+      }
+    ]
+  },
+  {
     "sectionHeader": "Google Summer of Code 2017",
     "tables": [
       {

--- a/src/content/programs.json
+++ b/src/content/programs.json
@@ -35,6 +35,41 @@
     ]
   },
   {
+    "sectionHeader": "Google Code-in 2019",
+    "tables": [
+      {
+        "title": "Google Code-in 2019 Projects",
+        "tableHeaders": [],
+        "tableRows": [
+          [
+            "Mentorship - Android",
+            "Mentorship - Backend"
+          ]
+        ]
+      },
+      {
+        "title": "Google Code-in 2019 Winners",
+        "tableHeaders": [
+          "Winners",
+          "Finalists",
+          "Runners up"
+        ],
+        "tableRows": [
+          [
+            "polabedz",
+            "HardikJH",
+            "i_maier"
+          ],
+          [
+            "BartekPacia",
+            "Menina",
+            "_daksha_"
+          ]
+        ]
+      }
+    ]
+  },
+  {
     "sectionHeader": "Google Summer of Code 2018",
     "tables": [
       {

--- a/src/content/programs.json
+++ b/src/content/programs.json
@@ -26,7 +26,7 @@
             "Vatsal Kulshreshtha\nAnna Bauza\nginny\nAkanksha Srivastava"
           ],
           [
-            "Open Source Programs",
+            "Open Source Programs (AnitaB Forms)",
             "Bismita Guha",
             "May\nMonal Shadi\nAbha Wadjikar\nsidvenu"
           ]

--- a/src/content/programs.json
+++ b/src/content/programs.json
@@ -401,5 +401,122 @@
         ]
       }
     ]
+  },
+  {
+    "sectionHeader": "Google Summer of Code 2015",
+    "tables": [
+      {
+        "title": "Peace Corps/Mobile Projects",
+        "tableHeaders": [
+          "Project",
+          "Students",
+          "Project Manager & Mentor",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "PeaceTrack Android",
+            "Bhagya (Sri Lanka)",
+            "Nicki (USA)",
+            "Neeraja (USA)\nPooja"
+          ],
+          [
+            "PeaceTrack iOS",
+            "Vennela (India)",
+            "Nicki (USA)",
+            "Jessica"
+          ],
+          [
+            "Malaria Android",
+            "Ankita (India)",
+            "Nicki (USA)\nRose (USA)",
+            "Aditi (India)\nAneke (Nigeria)"
+          ],
+          [
+            "Malaria iOS",
+            "Bruno (Portugal)",
+            "Nicki (USA)\nRose (USA)",
+            "Shanu (India)"
+          ],
+          [
+            "MACC",
+            "Irish - Malaria (Canada)\nAjay - PeaceTrack (India)",
+            "Nicki (USA)\nRose (USA)",
+            "Neeta (USA)\nNishita (India)\nVaibhavi (India)"
+          ],
+          [
+            "OVA Android",
+            "Ilo (Nigeria)",
+            "Rose (USA)",
+            "Dinu (Sri Lanka)"
+          ],
+          [
+            "OVA Android",
+            "Buddhiprabha (Sri Lanka)",
+            "Rose (USA)",
+            "Shruti (India)"
+          ],
+          [
+            "Ushahidi Guyana",
+            "Divya (India)",
+            "Rose (USA)",
+            "Julia (USA)\nJennifer (Austria)\nAngela (Kenya)\nLinda (Kenya)"
+          ],
+          [
+            "Language Translation",
+            "Won Wook (Seoul)\nIsuri (Sri Lanka)",
+            "Rose (USA)",
+            "Valerie (USA)\nKai (USA)\nMike (USA)\nSaumya (India)\nSylvain (France)"
+          ]
+        ]
+      },
+      {
+        "title": "Systers Projects",
+        "tableHeaders": [
+          "Project",
+          "Students",
+          "Project Manager & Mentor",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "Portal Meetup",
+            "Shaifali (India)",
+            "Rose (USA)",
+            "Ana (Moldova)\nChitra (India)\nJini (USA)"
+          ],
+          [
+            "Portal VMS",
+            "Valeria (Germany)",
+            "Rose (USA)\nSuzanne (USA)",
+            "Tapasweni (India)\nCarol (USA)"
+          ],
+          [
+            "Automation Testing",
+            "Daisy - MACC (Cameroon)\nKesha - Ushahidi (India)\nAnjali - Meetup (India)\nMadi - PLT (USA)\nJayesh - VMS (India)",
+            "Rose (USA)",
+            "Mariam\nSuryadip (USA)\nShwetambara (India)\nWendy (USA)\nKalena (USA)"
+          ],
+          [
+            "Mailman 3",
+            "Khushboo (India)\nNafisa (Canada)",
+            "Ana (Spain)",
+            "Stephen (Japan)\nPromita (USA)"
+          ],
+          [
+            "PowerUp iOS",
+            "Sanya (India)",
+            "Ihudiya (USA)\nRose (USA)",
+            "Deepika (India)\nJennifer (Austria)"
+          ],
+          [
+            "PowerUp Android",
+            "Chetna (India)",
+            "Ihudiya (USA)\nCindy\nEmily\nRose (USA)",
+            "Alma (UK)\nAna (Spain)"
+          ]
+        ]
+      }
+    ]
   }
 ]

--- a/src/content/programs.json
+++ b/src/content/programs.json
@@ -3,7 +3,7 @@
     "sectionHeader": "Google Summer of Code 2020",
     "tables": [
       {
-        "sectionHeader": "AnitaB.org Open Source 2020 Projects",
+        "title": "AnitaB.org Open Source 2020 Projects",
         "tableHeaders": [
           "Project",
           "Student",

--- a/src/content/programs.json
+++ b/src/content/programs.json
@@ -1,0 +1,130 @@
+[
+  {
+    "sectionHeader": "Google Summer of Code 2020",
+    "tables": [
+      {
+        "sectionHeader": "AnitaB.org Open Source 2020 Projects",
+        "tableHeaders": [
+          "Project",
+          "Student",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "BridgeInTech",
+            "Maya Treacy",
+            "Ramit Sawhney\nIsabel Costa\nFoong Min Wong\nMeenakshi Dhanani"
+          ],
+          [
+            "Enhancing Systers Portal",
+            "Ritwick Raj",
+            "May\nSakshi Munjal\nSammy\nSanket Dasgupta"
+          ],
+          [
+            "Mentorship iOS",
+            "Yugantar Jain",
+            "Vatsal Kulshreshtha\nAnna Bauza\nginny\nAkanksha Srivastava"
+          ],
+          [
+            "Open Source Programs",
+            "Bismita Guha",
+            "May\nMonal Shadi\nAbha Wadjikar\nsidvenu"
+          ]
+        ]
+      }
+    ]
+  },
+  {
+    "sectionHeader": "Google Summer of Code 2017",
+    "tables": [
+      {
+        "title": "Peace Corps Projects",
+        "tableHeaders": [
+          "Project",
+          "Student",
+          "Project Manager & Mentor",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "Photo Language Translation",
+            "Aditya",
+            "May",
+            "Prachi\nAnjali"
+          ],
+          [
+            "MACC",
+            "Gunpreet",
+            "Angel",
+            "Beiyu\nMedha"
+          ],
+          [
+            "MACC",
+            "Yatna",
+            "Angel",
+            "Beiyu\nMedha"
+          ],
+          [
+            "PC Prep Kit",
+            "SJ Rajath",
+            "Buddhiprabha",
+            "Visitha\nRhythm"
+          ],
+          [
+            "PC Prep Kit",
+            "Shreyans",
+            "Buddhiprabha",
+            "Jennifer\nVisitha"
+          ]
+        ]
+      },
+      {
+        "title": "Systers Projects",
+        "tableHeaders": [
+          "Project",
+          "Student",
+          "Project Manager & Mentor",
+          "Mentors"
+        ],
+        "tableRows": [
+          [
+            "Hoppers App iOS",
+            "Connie",
+            "May",
+            "Shruti\nBruno\nPichleap"
+          ],
+          [
+            "Hoppers App Android",
+            "Divya",
+            "May",
+            "Himanshi\nDinu"
+          ],
+          [
+            "PowerUp UI/UX/Graphics",
+            "Kim",
+            "May",
+            "Dilushi"
+          ],
+          [
+            "PowerUp Android",
+            "Sachin",
+            "May",
+            "Dhara\nAanchal"
+          ],
+          [
+            "PowerUp iOS",
+            "Yu",
+            "May",
+            "Sally\nGinny\nJennifer"
+          ],
+          [
+            "Mailman 3",
+            "Aditi",
+            "May",
+            "Vatsala\nKhushali\nRosario\nStephen"
+          ]
+        ]
+      }
+    ]
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3975,6 +3975,15 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -3990,12 +3999,24 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
   integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
 
+domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+domhandler@4.2.2, domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
+  integrity sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
+  dependencies:
+    domelementtype "^2.2.0"
 
 domhandler@^2.3.0:
   version "2.4.2"
@@ -4019,6 +4040,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.5.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -5360,6 +5390,14 @@ html-comment-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
   integrity sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
 
+html-dom-parser@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-1.0.2.tgz#bb5ff844f214657d899aa4fb7b0a9e7d15607e96"
+  integrity sha512-Jq4oVkVSn+10ut3fyc2P/Fs1jqTo0l45cP6Q8d2ef/9jfkYwulO0QXmyLI0VUiZrXF4czpGgMEJRa52CQ6Fk8Q==
+  dependencies:
+    domhandler "4.2.2"
+    htmlparser2 "6.1.0"
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -5390,6 +5428,16 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
+html-react-parser@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-1.4.0.tgz#bf264f38b9fdf4d94e2120f6a39586c15cb81bd0"
+  integrity sha512-v8Kxy+7L90ZFSM690oJWBNRzZWZOQquYPpQt6kDQPzQyZptXgOJ69kHSi7xdqNdm1mOfsDPwF4K9Bo/dS5gRTQ==
+  dependencies:
+    domhandler "4.2.2"
+    html-dom-parser "1.0.2"
+    react-property "2.0.0"
+    style-to-js "1.1.0"
+
 html-webpack-plugin@4.0.0-beta.11:
   version "4.0.0-beta.11"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz#3059a69144b5aecef97708196ca32f9e68677715"
@@ -5401,6 +5449,16 @@ html-webpack-plugin@4.0.0-beta.11:
     pretty-error "^2.1.1"
     tapable "^1.1.3"
     util.promisify "1.0.0"
+
+htmlparser2@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 htmlparser2@^3.3.0:
   version "3.10.1"
@@ -5640,6 +5698,11 @@ ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 inline-style-prefixer@^5.1.0:
   version "5.1.2"
@@ -9038,6 +9101,11 @@ react-native-web@^0.12.2:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
 
+react-property@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
+  integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
+
 react-scripts@^3.4.1:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-3.4.4.tgz#eef024ed5c566374005e3f509877350ba99d08a7"
@@ -10260,6 +10328,20 @@ style-loader@0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
+style-to-js@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.0.tgz#631cbb20fce204019b3aa1fcb5b69d951ceac4ac"
+  integrity sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==
+  dependencies:
+    style-to-object "0.3.0"
+
+style-to-object@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
+  integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
+  dependencies:
+    inline-style-parser "0.1.1"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -10597,11 +10679,6 @@ ua-parser-js@^0.7.18:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
-
-uc.micro@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
-  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uc.micro@^1.0.1:
   version "1.0.6"


### PR DESCRIPTION
### Description

Currently working on adding a table component for displaying this data.
The idea is to have a section component that will hold the data and possibly be collapsible, and a child table component that will display the data. I want the table to be as flexible as possible, so that it could potentially be used for other things as well.

Relevant links:
https://summerofcode.withgoogle.com/archive/2020/organizations/5270382996619264/
https://codein.withgoogle.com/archive/2019/organization/5698265715048448/
https://summerofcode.withgoogle.com/archive/2018/organizations/6321870005600256/
https://summerofcode.withgoogle.com/archive/2017/organizations/5429781541683200/

https://systers.io/gsoc/2017.html
https://systers.io/gsoc/2016.html
https://systers.io/gsoc/2015.html

https://systers.io/#programs

Fixes #308

### Type of Change:

- Code
- User Interface
- Outreach
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
The changes generate no warnings or errors, and the site has been deployed to 
https://wizardlemon.github.io/anitab-org.github.io/
The changes are under the programs tab.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have attached link of deployed site.
- [x] Any dependent changes have been merged
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
