### PR TITLE
chore: remove prettier job from gh action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,25 +13,6 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow formats the code with our linter (Prettier) and then builds
-  prettier:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.event.pull_request.base.ref }}
-
-          # This is important to fetch the changes to the previous commit
-          fetch-depth: 0
-
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.0
-        with:
-          prettier_options: "--write src/**/*.{ts,jsx,js,css,html,json,md}"
-          only_changed: True
   build:
     # The type of runner that the job will run on
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
### Description

I am removing the `prettier` GitHub action job to unblock the deployment of this website, which is currently not working.

### Type of Change:

- Code

### How Has This Been Tested?

<!-- If you are working on a design then add a gif to show the responsiveness of your design.
Please follow [testing guidelines](https://github.com/anitab-org/anitab-org.github.io/wiki/Prepare-testing-GitHub-Pages-for-your-PR) and share the link of deployed site here. -->

Will test once merged. Also, the check on this PR should not fail.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] ~I have commented my code or provided relevant documentation, particularly in hard-to-understand areas~
- [x] ~I have made corresponding changes to the documentation~
- [x] ~I have attached link of deployed site.~
- [x] ~Any dependent changes have been merged~
